### PR TITLE
Fix DynamicRtree.query/2 and DynamicRtree.pquery/3 typespecs

### DIFF
--- a/lib/ddrt/dynamic_rtree.ex
+++ b/lib/ddrt/dynamic_rtree.ex
@@ -27,8 +27,9 @@ defmodule DDRT.DynamicRtree do
   @callback delete(ids :: id() | [id()], name :: GenServer.name()) :: {:ok, map()}
   @callback insert(leaves :: leaf() | [leaf()], name :: GenServer.name()) :: {:ok, map()}
   @callback metadata(name :: GenServer.name()) :: map()
-  @callback pquery(box :: bounding_box(), depth :: integer(), name :: GenServer.name()) :: [id()]
-  @callback query(box :: bounding_box(), name :: GenServer.name()) :: [id()]
+  @callback pquery(box :: bounding_box(), depth :: integer(), name :: GenServer.name()) ::
+              {:ok, [id()]}
+  @callback query(box :: bounding_box(), name :: GenServer.name()) :: {:ok, [id()]}
   @callback update(
               ids :: id(),
               box :: bounding_box() | {bounding_box(), bounding_box()},
@@ -217,7 +218,7 @@ defmodule DDRT.DynamicRtree do
 
   """
 
-  @spec query(box :: bounding_box(), name :: GenServer.name()) :: [id()]
+  @spec query(box :: bounding_box(), name :: GenServer.name()) :: {:ok, [id()]}
   def query(box, name \\ DDRT) do
     GenServer.call(name, {:query, box})
   end
@@ -228,7 +229,8 @@ defmodule DDRT.DynamicRtree do
     Returns `[id's]`.
   """
 
-  @spec pquery(box :: bounding_box(), depth :: integer(), name :: GenServer.name()) :: [id()]
+  @spec pquery(box :: bounding_box(), depth :: integer(), name :: GenServer.name()) ::
+          {:ok, [id()]}
   def pquery(box, depth, name \\ DDRT) do
     GenServer.call(name, {:query_depth, {box, depth}})
   end


### PR DESCRIPTION
While using this great lib I noticed two typespecs were a bit off. Two ways of fixing this: changing what these two functions return (but it would be a breaking change) or changing the typespecs. I went for the latter, happy to go the other route if that's what you'd prefer.